### PR TITLE
feat: support loading ESM applications

### DIFF
--- a/adonis-typings/application.ts
+++ b/adonis-typings/application.ts
@@ -335,7 +335,7 @@ declare module '@ioc:Adonis/Core/Application' {
 		 * Apart from the providers, most of the app including the container
 		 * is ready at this stage
 		 */
-		setup(): void
+		setup(): Promise<void>
 
 		/**
 		 * Register providers

--- a/adonis-typings/application.ts
+++ b/adonis-typings/application.ts
@@ -162,6 +162,11 @@ declare module '@ioc:Adonis/Core/Application' {
 		readonly typescript: boolean
 
 		/**
+		 * Whether the application is written in CommonJS or ESM.
+		 */
+		readonly type: 'commonjs' | 'module'
+
+		/**
 		 * Application environment.
 		 *
 		 * - `console` is when running ace commands
@@ -340,7 +345,7 @@ declare module '@ioc:Adonis/Core/Application' {
 		/**
 		 * Register providers
 		 */
-		registerProviders(): void
+		registerProviders(): Promise<void>
 
 		/**
 		 * Booted providers

--- a/adonis-typings/application.ts
+++ b/adonis-typings/application.ts
@@ -350,7 +350,7 @@ declare module '@ioc:Adonis/Core/Application' {
 		/**
 		 * Registers the providers
 		 */
-		requirePreloads(): void
+		requirePreloads(): Promise<void>
 
 		/**
 		 * Start the application. At this time we execute the provider's

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            December 20th 2020, 12:48:24 pm
+                            December 20th 2020, 2:47:23 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            December 20th 2020, 12:25:44 pm
+                            December 20th 2020, 12:48:24 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -47,7 +47,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            36
+                            0
                         </h5>
                         <p class="card-text">Dependencies</p>
                     </div>
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            November 24th 2020, 4:02:18 pm
+                            December 20th 2020, 12:25:44 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            December 20th 2020, 2:47:23 pm
+                            December 20th 2020, 3:05:47 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/src/Application.ts
+++ b/src/Application.ts
@@ -40,9 +40,16 @@ async function importAll(path: string) {
 			(entry.name.endsWith('.js') || (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')))
 		) {
 			const name = basename(entry.name, extname(entry.name))
-			result[name] = await import(pathToFileURL(join(path, entry.name)).href)
+			const imported = await import(pathToFileURL(join(path, entry.name)).href)
+			const importedKeys = Object.keys(imported)
+			if (importedKeys.length === 1 && importedKeys[0] === 'default') {
+				result[name] = imported.default
+			} else {
+				result[name] = imported
+			}
 		}
 	}
+	return result
 }
 
 /**
@@ -423,7 +430,7 @@ export class Application implements ApplicationContract {
 		if (this.type === 'commonjs') {
 			this.config = new Config(requireAll(this.configPath()))
 		} else {
-			this.config = await new Config(importAll(this.configPath()))
+			this.config = new Config(await importAll(this.configPath()))
 		}
 		this.container.singleton('Adonis/Core/Config', () => this.config)
 	}

--- a/src/Application.ts
+++ b/src/Application.ts
@@ -658,23 +658,23 @@ export class Application implements ApplicationContract {
 	/**
 	 * Register providers
 	 */
-	public registerProviders(): void {
+	public async registerProviders(): Promise<void> {
 		if (this.state !== 'setup') {
 			return
 		}
 
 		this.state = 'registered'
 
-		this.profiler.profile('providers:register', {}, () => {
+		await this.profiler.profileAsync('providers:register', {}, async () => {
 			const providers =
 				this.environment !== 'web'
 					? this.rcFile.providers.concat(this.rcFile.aceProviders)
 					: this.rcFile.providers
 
 			this.logger.trace('registering providers', providers)
-			this.registrar = new Registrar([this], this.appRoot)
+			this.registrar = new Registrar([this], this.appRoot, this.type === 'module')
 
-			const registeredProviders = this.registrar
+			const registeredProviders = await this.registrar
 				.useProviders(providers, (provider) => {
 					return new provider(provider['needsApplication'] ? this : this.container)
 				})

--- a/test/application.spec.ts
+++ b/test/application.spec.ts
@@ -699,7 +699,7 @@ test.group('Application | requirePreloads', (group) => {
 		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
-		app.requirePreloads()
+		await app.requirePreloads()
 
 		assert.equal(app.container.use('Start/Foo'), 'foo')
 	})
@@ -729,7 +729,7 @@ test.group('Application | requirePreloads', (group) => {
 		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
-		app.requirePreloads()
+		await app.requirePreloads()
 
 		assert.isFalse(app.container.hasBinding('Start/Foo'))
 	})
@@ -759,7 +759,7 @@ test.group('Application | requirePreloads', (group) => {
 		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
-		app.requirePreloads()
+		await app.requirePreloads()
 
 		assert.equal(app.container.use('Start/Foo'), 'foo')
 	})
@@ -781,7 +781,7 @@ test.group('Application | requirePreloads', (group) => {
 		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
-		app.requirePreloads()
+		await app.requirePreloads()
 
 		assert.isFalse(app.container.hasBinding('Start/Foo'))
 	})
@@ -803,12 +803,16 @@ test.group('Application | requirePreloads', (group) => {
 		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
-		const fn = () => app.requirePreloads()
 
-		assert.throw(
-			fn,
-			`ENOENT: no such file or directory, open '${join(fs.basePath, 'start/foo.ts')}'`
-		)
+		try {
+			await app.requirePreloads()
+			assert.fail('unreachable')
+		} catch (err) {
+			assert.strictEqual(
+				err.message,
+				`ENOENT: no such file or directory, open '${join(fs.basePath, 'start/foo.ts')}'`
+			)
+		}
 	})
 
 	test('raise error when file has errors other then ENOENT', async (assert) => {
@@ -837,9 +841,13 @@ test.group('Application | requirePreloads', (group) => {
 		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
-		const fn = () => app.requirePreloads()
 
-		assert.throw(fn, `global.ioc.use is not a function`)
+		try {
+			await app.requirePreloads()
+			assert.fail('unreachable')
+		} catch (err) {
+			assert.strictEqual(err.message, `global.ioc.use is not a function`)
+		}
 	})
 })
 

--- a/test/application.spec.ts
+++ b/test/application.spec.ts
@@ -182,7 +182,7 @@ test.group('Application', (group) => {
 		await fs.fsExtra.ensureDir(join(fs.basePath, 'config'))
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		const fn = () => app.switchEnvironment('repl')
 		assert.throw(fn, 'Cannot switch application environment in "setup" state')
@@ -208,7 +208,7 @@ test.group('Application | setup', (group) => {
 			},
 		})
 
-		app.setup()
+		await app.setup()
 		assert.deepEqual(app.container.directoryAliases, {
 			App: join(fs.basePath, './app'),
 		})
@@ -219,7 +219,7 @@ test.group('Application | setup', (group) => {
 		await fs.fsExtra.ensureDir(join(fs.basePath, 'config'))
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		assert.equal(process.env.ENV_APP_NAME, 'adonisjs')
 	})
@@ -238,17 +238,21 @@ test.group('Application | setup', (group) => {
 		)
 
 		const app = getApp({})
-		const fn = () => app.setup()
-		assert.throw(
-			fn,
-			'E_INVALID_ENV_VALUE: Value for environment variable "ENV_APP_NAME" must be one of "adonisjs,adonis"'
-		)
+		try {
+			await app.setup()
+			assert.fail('unreachable')
+		} catch (err) {
+			assert.equal(
+				err.message,
+				'E_INVALID_ENV_VALUE: Value for environment variable "ENV_APP_NAME" must be one of "adonisjs,adonis", instead received "foo"'
+			)
+		}
 	})
 
 	test('do no t raise error when .env file is missing', async () => {
 		await fs.fsExtra.ensureDir(join(fs.basePath, 'config'))
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 	})
 
 	test('load env file from a different location', async (assert) => {
@@ -257,7 +261,7 @@ test.group('Application | setup', (group) => {
 		await fs.fsExtra.ensureDir(join(fs.basePath, 'config'))
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		assert.equal(process.env.ENV_APP_NAME, 'adonisjs')
 	})
@@ -267,7 +271,7 @@ test.group('Application | setup', (group) => {
 		await fs.fsExtra.ensureDir(join(fs.basePath, 'config'))
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		assert.equal(app.nodeEnvironment, 'development')
 	})
@@ -277,7 +281,7 @@ test.group('Application | setup', (group) => {
 		await fs.fsExtra.ensureDir(join(fs.basePath, 'config'))
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		assert.equal(app.nodeEnvironment, 'development')
 	})
@@ -287,7 +291,7 @@ test.group('Application | setup', (group) => {
 		await fs.fsExtra.ensureDir(join(fs.basePath, 'config'))
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		assert.equal(app.nodeEnvironment, 'staging')
 	})
@@ -297,7 +301,7 @@ test.group('Application | setup', (group) => {
 		await fs.fsExtra.ensureDir(join(fs.basePath, 'config'))
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		assert.equal(app.nodeEnvironment, 'staging')
 	})
@@ -307,7 +311,7 @@ test.group('Application | setup', (group) => {
 		await fs.fsExtra.ensureDir(join(fs.basePath, 'config'))
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		assert.equal(app.nodeEnvironment, 'production')
 	})
@@ -317,7 +321,7 @@ test.group('Application | setup', (group) => {
 		await fs.fsExtra.ensureDir(join(fs.basePath, 'config'))
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		assert.equal(app.nodeEnvironment, 'production')
 	})
@@ -327,7 +331,7 @@ test.group('Application | setup', (group) => {
 		await fs.fsExtra.ensureDir(join(fs.basePath, 'config'))
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		assert.equal(app.nodeEnvironment, 'testing')
 	})
@@ -337,7 +341,7 @@ test.group('Application | setup', (group) => {
 		await fs.fsExtra.ensureDir(join(fs.basePath, 'config'))
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		assert.equal(app.nodeEnvironment, 'testing')
 	})
@@ -352,7 +356,7 @@ test.group('Application | setup', (group) => {
 		)
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		const Config = app.container.use('Adonis/Core/Config')
 		assert.equal(Config.get('app.logger.name'), 'foobar')
@@ -368,7 +372,7 @@ test.group('Application | setup', (group) => {
 		)
 
 		const app = getApp({})
-		app.setup()
+		await app.setup()
 
 		assert.instanceOf(app.container.use('Adonis/Core/Logger'), Logger)
 		assert.instanceOf(app.container.use('Adonis/Core/Profiler'), Profiler)
@@ -430,7 +434,7 @@ test.group('Application | registerProviders', (group) => {
 			aceProviders: ['./providers/AceProvider'],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 
 		assert.equal(app.container.use('App/Foo'), 'foo')
@@ -484,7 +488,7 @@ test.group('Application | registerProviders', (group) => {
 			aceProviders: ['./providers/AceProvider'],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 
 		assert.equal(app.container.use('App/Foo'), 'foo')
@@ -539,7 +543,7 @@ test.group('Application | registerProviders', (group) => {
 			providers: ['./providers/AppProvider'],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 
 		assert.equal(app.container.use('App/Foo'), 'foo')
@@ -603,7 +607,7 @@ test.group('Application | bootProviders', (group) => {
 			providers: ['./providers/AppProvider'],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
 
@@ -658,7 +662,7 @@ test.group('Application | bootProviders', (group) => {
 			aceProviders: ['./providers/AceProvider'],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
 
@@ -692,7 +696,7 @@ test.group('Application | requirePreloads', (group) => {
 			preloads: ['./start/foo'],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
 		app.requirePreloads()
@@ -722,7 +726,7 @@ test.group('Application | requirePreloads', (group) => {
 			],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
 		app.requirePreloads()
@@ -752,7 +756,7 @@ test.group('Application | requirePreloads', (group) => {
 			],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
 		app.requirePreloads()
@@ -774,7 +778,7 @@ test.group('Application | requirePreloads', (group) => {
 			],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
 		app.requirePreloads()
@@ -796,7 +800,7 @@ test.group('Application | requirePreloads', (group) => {
 			],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
 		const fn = () => app.requirePreloads()
@@ -830,7 +834,7 @@ test.group('Application | requirePreloads', (group) => {
 			],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
 		const fn = () => app.requirePreloads()
@@ -874,7 +878,7 @@ test.group('Application | start', (group) => {
 			providers: ['./providers/AppProvider'],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
 		await app.start()
@@ -918,7 +922,7 @@ test.group('Application | start', (group) => {
 			providers: ['./providers/AppProvider'],
 		})
 
-		app.setup()
+		await app.setup()
 		app.registerProviders()
 		await app.bootProviders()
 		await app.start()

--- a/test/application.spec.ts
+++ b/test/application.spec.ts
@@ -435,7 +435,7 @@ test.group('Application | registerProviders', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 
 		assert.equal(app.container.use('App/Foo'), 'foo')
 		assert.isFalse(app.container.hasBinding('Ace/Foo'))
@@ -489,7 +489,7 @@ test.group('Application | registerProviders', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 
 		assert.equal(app.container.use('App/Foo'), 'foo')
 		assert.equal(app.container.use('Ace/Foo'), 'foo')
@@ -544,7 +544,7 @@ test.group('Application | registerProviders', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 
 		assert.equal(app.container.use('App/Foo'), 'foo')
 		assert.equal(app.container.use('Main/Foo'), 'foo')
@@ -608,7 +608,7 @@ test.group('Application | bootProviders', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 		await app.bootProviders()
 
 		assert.equal(app.container.use('App/Foo'), 'foo')
@@ -663,7 +663,7 @@ test.group('Application | bootProviders', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 		await app.bootProviders()
 
 		assert.equal(app.container.use('App/Foo'), 'foo')
@@ -697,7 +697,7 @@ test.group('Application | requirePreloads', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 		await app.bootProviders()
 		await app.requirePreloads()
 
@@ -727,7 +727,7 @@ test.group('Application | requirePreloads', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 		await app.bootProviders()
 		await app.requirePreloads()
 
@@ -757,7 +757,7 @@ test.group('Application | requirePreloads', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 		await app.bootProviders()
 		await app.requirePreloads()
 
@@ -779,7 +779,7 @@ test.group('Application | requirePreloads', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 		await app.bootProviders()
 		await app.requirePreloads()
 
@@ -801,7 +801,7 @@ test.group('Application | requirePreloads', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 		await app.bootProviders()
 
 		try {
@@ -839,7 +839,7 @@ test.group('Application | requirePreloads', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 		await app.bootProviders()
 
 		try {
@@ -887,7 +887,7 @@ test.group('Application | start', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 		await app.bootProviders()
 		await app.start()
 
@@ -931,7 +931,7 @@ test.group('Application | start', (group) => {
 		})
 
 		await app.setup()
-		app.registerProviders()
+		await app.registerProviders()
 		await app.bootProviders()
 		await app.start()
 		await app.shutdown()


### PR DESCRIPTION
Work in progress.
Need to find out how to prevent TypeScript from transpiling the dynamic import call:

```js
    resolveModule(modulePath, onMissingCallback) {
        let filePath;
        try {
            filePath = utils_1.resolveFrom(this.appRoot, modulePath);
            return this.type === 'commonjs' || filePath.endsWith('.json')
                ? require(filePath)
                : Promise.resolve().then(() => __importStar(require(filePath)));
        }
        catch (error) {
            if (['ENOENT', 'MODULE_NOT_FOUND'].includes(error.code) &&
                (!filePath || filePath === error.path)) {
                return onMissingCallback(error);
            }
            else {
                throw error;
            }
        }
    }
```