### PR TITLE
refactor: deprecate makePathFromCwd in favor of makePath

### DIFF
--- a/adonis-typings/application.ts
+++ b/adonis-typings/application.ts
@@ -268,6 +268,7 @@ declare module '@ioc:Adonis/Core/Application' {
 
     /**
      * Make path to a file or directory from the application source root
+     * @deprecated Use `makePath` instead
      */
     makePathFromCwd(...paths: string[]): string
 

--- a/src/Application.ts
+++ b/src/Application.ts
@@ -470,8 +470,13 @@ export class Application implements ApplicationContract {
    * Makes the path to a directory from `cliCwd` vs the `appRoot`. This is
    * helpful when we want path inside the project root and not the
    * build directory
+   * @deprecated Use `makePath` instead
    */
   public makePathFromCwd(...paths: string[]): string {
+    process.emitWarning(
+      'DeprecationWarning',
+      'application.makePathFromCwd() is deprecated. Use application.makePath() instead'
+    )
     return join(this.cliCwd || this.appRoot, ...paths)
   }
   /**


### PR DESCRIPTION
The function is no longer necessary now that the dev server uses in-memory TypeScript compilation.