### PR TITLE
feat: allow false value for assetsBundler

### DIFF
--- a/src/rc_file/parser.ts
+++ b/src/rc_file/parser.ts
@@ -59,6 +59,10 @@ export class RcFileParser {
    * Returns the assets bundler object
    */
   #getAssetsBundler(): RcFile['assetsBundler'] {
+    if (this.#rcFile.assetsBundler === false) {
+      return false
+    }
+
     if (!this.#rcFile.assetsBundler) {
       return
     }
@@ -195,7 +199,7 @@ export class RcFileParser {
 
     return {
       typescript: this.#rcFile.typescript,
-      ...(assetsBundler ? { assetsBundler } : {}),
+      ...(assetsBundler !== undefined ? { assetsBundler } : {}),
       preloads: this.#getPreloads(),
       metaFiles: this.#getMetaFiles(),
       commands: [...this.#rcFile.commands],

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,18 +126,22 @@ export type RcFile = {
    *
    * This config can be used to configure assets bundler apart from
    * vite and encore (since both are auto-detected)
+   *
+   * Set it to `false` to disable the assets bundler
    */
-  assetsBundler?: {
-    name: string
-    devServer: {
-      command: string
-      args?: string[]
-    }
-    build: {
-      command: string
-      args?: string[]
-    }
-  }
+  assetsBundler?:
+    | {
+        name: string
+        devServer: {
+          command: string
+          args?: string[]
+        }
+        build: {
+          command: string
+          args?: string[]
+        }
+      }
+    | false
 
   /**
    * Is it a TypeScript project

--- a/tests/rc_file/parser.spec.ts
+++ b/tests/rc_file/parser.spec.ts
@@ -656,6 +656,27 @@ test.group('Rc Parser | assetsBundler', () => {
       'Invalid assetsBundler entry. Missing name property'
     )
   })
+
+  test('parse assetsBundler false', ({ assert }) => {
+    const parser = new RcFileParser({ assetsBundler: false })
+
+    assert.deepEqual(parser.parse(), {
+      raw: { assetsBundler: false },
+      typescript: true,
+      assetsBundler: false,
+      preloads: [],
+      directories,
+      metaFiles: [],
+      commands: [],
+      commandsAliases: {},
+      providers: [],
+      tests: {
+        suites: [],
+        timeout: 2000,
+        forceExit: true,
+      },
+    })
+  })
 })
 
 test.group('Rc Parser | directories', () => {


### PR DESCRIPTION
Allow passing `false` to `assetsBundler`

Having `assetsBundler` to false means that we must completely disable the assets bundler managed by the assembler. 
Today if you don't pass anything to assetsBundler, the bundler is automatically detected and started by the assembler. 

This is something we want to avoid with the new version of Vite, as @adonisjs/vite will launch the dev server itself. The assembler won't have to manage anything