### PR TITLE
feat: add assembler configuration (unstable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@japa/expect-type": "^2.0.1",
     "@japa/file-system": "^2.2.0",
     "@japa/runner": "^3.1.1",
+    "@poppinss/cliui": "^6.4.0",
     "@swc/core": "^1.3.106",
     "@types/fs-extra": "^11.0.4",
     "@types/glob-parent": "^5.1.3",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -97,3 +97,21 @@ export const E_MISSING_BUNDLER_NAME = createError(
   'Invalid assetsBundler entry. Missing name property',
   'E_MISSING_BUNDLER_NAME'
 )
+
+/**
+ * The exception is raised when the "name" is missing
+ * in assembler.runner object
+ */
+export const E_MISSING_ASSEMBLER_RUNNER_NAME = createError(
+  'Invalid assembler.runner entry. Missing name property',
+  'E_MISSING_ASSEMBLER_RUNNER_NAME'
+)
+
+/**
+ * The exception is raised when the "command" is missing
+ * in assembler.runner object
+ */
+export const E_MISSING_ASSEMBLER_RUNNER_COMMAND = createError(
+  'Invalid assembler.runner entry. Missing command property',
+  'E_MISSING_ASSEMBLER_RUNNER_COMMAND'
+)

--- a/src/rc_file/parser.ts
+++ b/src/rc_file/parser.ts
@@ -90,43 +90,40 @@ export class RcFileParser {
   /**
    * Returns the assembler runner object
    */
-  #getAssemblerRunner(): NonNullable<RcFile['assembler']>['runner'] {
-    if (!this.#rcFile.assembler?.runner) {
+  #getAssemblerRunner(): NonNullable<RcFile['unstable_assembler']>['runner'] {
+    if (!this.#rcFile.unstable_assembler?.runner) {
       return
     }
 
-    if (!this.#rcFile.assembler.runner.name) {
+    if (!this.#rcFile.unstable_assembler.runner.name) {
       throw new errors.E_MISSING_ASSEMBLER_RUNNER_NAME()
     }
 
-    if (!this.#rcFile.assembler.runner.command) {
+    if (!this.#rcFile.unstable_assembler.runner.command) {
       throw new errors.E_MISSING_ASSEMBLER_RUNNER_COMMAND()
     }
 
     return {
-      name: this.#rcFile.assembler.runner.name,
-      command: this.#rcFile.assembler.runner.command,
-      args: this.#rcFile.assembler.runner.args,
+      name: this.#rcFile.unstable_assembler.runner.name,
+      command: this.#rcFile.unstable_assembler.runner.command,
+      args: this.#rcFile.unstable_assembler.runner.args,
     }
   }
 
   /**
    * Returns the assembler object
    */
-  #getAssembler(): RcFile['assembler'] {
-    if (!this.#rcFile.assembler) {
+  #getAssembler(): RcFile['unstable_assembler'] {
+    if (!this.#rcFile.unstable_assembler) {
       return
     }
 
     const runner = this.#getAssemblerRunner()
     return new ObjectBuilder({})
       .add('runner', runner)
-      .add('onBuildStarting', this.#rcFile.assembler.onBuildStarting)
-      .add('onBuildCompleted', this.#rcFile.assembler.onBuildCompleted)
-      .add('onDevServerClosed', this.#rcFile.assembler.onDevServerClosed)
-      .add('onDevServerClosing', this.#rcFile.assembler.onDevServerClosing)
-      .add('onDevServerStarted', this.#rcFile.assembler.onDevServerStarted)
-      .add('onDevServerStarting', this.#rcFile.assembler.onDevServerStarting)
+      .add('onBuildStarting', this.#rcFile.unstable_assembler.onBuildStarting)
+      .add('onBuildCompleted', this.#rcFile.unstable_assembler.onBuildCompleted)
+      .add('onDevServerStarted', this.#rcFile.unstable_assembler.onDevServerStarted)
       .toObject()
   }
 
@@ -244,7 +241,7 @@ export class RcFileParser {
 
     return {
       typescript: this.#rcFile.typescript,
-      ...(assembler ? { assembler } : {}),
+      ...(assembler ? { unstable_assembler: assembler } : {}),
       ...(assetsBundler !== undefined ? { assetsBundler } : {}),
       preloads: this.#getPreloads(),
       metaFiles: this.#getMetaFiles(),

--- a/src/rc_file/parser.ts
+++ b/src/rc_file/parser.ts
@@ -59,6 +59,10 @@ export class RcFileParser {
    * Returns the assets bundler object
    */
   #getAssetsBundler(): RcFile['assetsBundler'] {
+    if (this.#rcFile.assetsBundler === false) {
+      return false
+    }
+
     if (!this.#rcFile.assetsBundler) {
       return
     }
@@ -195,7 +199,7 @@ export class RcFileParser {
 
     return {
       typescript: this.#rcFile.typescript,
-      ...(assetsBundler ? { assetsBundler } : {}),
+      ...(assetsBundler !== undefined ? { assetsBundler } : {}),
       preloads: this.#getPreloads(),
       metaFiles: this.#getMetaFiles(),
       commands: [...this.#rcFile.commands],

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@
  */
 
 import type { Logger } from '@poppinss/cliui'
+import type { Colors } from '@poppinss/cliui/types'
+
 import type { Application } from './application.js'
 
 /**
@@ -57,12 +59,12 @@ export type AssemblerHookNode<Handler extends Function> = () => Promise<{ defaul
 /**
  * Handler for the assembler hooks
  */
-export type AssemblerHookHandler = (logger: Logger) => any
+export type AssemblerHookHandler = (ui: { logger: Logger, colors: Colors }) => any
 
 /**
  * Handler for the source file changed hook
  */
-export type SourceFileChangedHookHandler = (filePath: string, logger: Logger) => any
+export type SourceFileChangedHookHandler = (ui: { logger: Logger, colors: Colors }, filePath: string) => any
 
 /**
  * Shape of directories object with known and unknown
@@ -204,7 +206,7 @@ export type RcFile = {
   /**
    * Assembler configuration
    */
-  assembler?: {
+  unstable_assembler?: {
     /**
      * Configure a custom runner to start the dev server
      * and tests. By default we are using ts-node but you
@@ -222,24 +224,9 @@ export type RcFile = {
     onDevServerStarted?: AssemblerHookNode<AssemblerHookHandler>[]
 
     /**
-     * When the dev server is about to start
-     */
-    onDevServerStarting?: AssemblerHookNode<AssemblerHookHandler>[]
-
-    /**
      * When a source file changes
      */
     onSourceFileChanged?: AssemblerHookNode<SourceFileChangedHookHandler>[]
-
-    /**
-     * When the dev server is about to close
-     */
-    onDevServerClosing?: AssemblerHookNode<AssemblerHookHandler>[]
-
-    /**
-     * When the dev server is closed
-     */
-    onDevServerClosed?: AssemblerHookNode<AssemblerHookHandler>[]
 
     /**
      * When a build is started

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,7 +283,7 @@ export interface RcFileInput {
     timeout?: number
   }
   providers?: (ProviderNode | ProviderNode['file'])[]
-  assembler?: RcFile['assembler']
+  unstable_assembler?: RcFile['unstable_assembler']
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,21 @@ export type HooksState<ContainerBindings extends Record<any, any>> = [
 ]
 
 /**
+ * Shape of an Assembler hook file
+ */
+export type AssemblerHookNode<Handler extends Function> = () => Promise<{ default: Handler }>
+
+/**
+ * Handler for the assembler hooks
+ */
+export type AssemblerHookHandler = (logger: Logger) => any
+
+/**
+ * Handler for the source file changed hook
+ */
+export type SourceFileChangedHookHandler = (filePath: string, logger: Logger) => any
+
+/**
  * Shape of directories object with known and unknown
  * directories
  */
@@ -116,21 +131,6 @@ export type MetaFileNode = {
   pattern: string
   reloadServer: boolean
 }
-
-/**
- * Shape of an Assembler hook file
- */
-export type AssemblerHookNode<Handler extends Function> = () => Promise<{ default: Handler }>
-
-/**
- * Handler for the assembler hooks
- */
-export type AssemblerHookHandler = (logger: Logger) => any
-
-/**
- * Handler for the source file changed hook
- */
-export type SourceFileChangedHookHandler = (filePath: string, logger: Logger) => any
 
 /**
  * Shape of the adonisrc.js file

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,12 +59,15 @@ export type AssemblerHookNode<Handler extends Function> = () => Promise<{ defaul
 /**
  * Handler for the assembler hooks
  */
-export type AssemblerHookHandler = (ui: { logger: Logger, colors: Colors }) => any
+export type AssemblerHookHandler = (ui: { logger: Logger; colors: Colors }) => any
 
 /**
  * Handler for the source file changed hook
  */
-export type SourceFileChangedHookHandler = (ui: { logger: Logger, colors: Colors }, filePath: string) => any
+export type SourceFileChangedHookHandler = (
+  ui: { logger: Logger; colors: Colors },
+  filePath: string
+) => any
 
 /**
  * Shape of directories object with known and unknown

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,18 +126,22 @@ export type RcFile = {
    *
    * This config can be used to configure assets bundler apart from
    * vite and encore (since both are auto-detected)
+   *
+   * Set it to `false` to disable the assets bundler
    */
-  assetsBundler?: {
-    name: string
-    devServer: {
-      command: string
-      args?: string[]
-    }
-    build: {
-      command: string
-      args?: string[]
-    }
-  }
+  assetsBundler?:
+    | {
+        name: string
+        devServer: {
+          command: string
+          args?: string[]
+        }
+        build: {
+          command: string
+          args?: string[]
+        }
+      }
+    | false
 
   /**
    * Is it a TypeScript project

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 
+import type { Logger } from '@poppinss/cliui'
 import type { Application } from './application.js'
 
 /**
@@ -117,6 +118,21 @@ export type MetaFileNode = {
 }
 
 /**
+ * Shape of an Assembler hook file
+ */
+export type AssemblerHookNode<Handler extends Function> = () => Promise<{ default: Handler }>
+
+/**
+ * Handler for the assembler hooks
+ */
+export type AssemblerHookHandler = (logger: Logger) => any
+
+/**
+ * Handler for the source file changed hook
+ */
+export type SourceFileChangedHookHandler = (filePath: string, logger: Logger) => any
+
+/**
  * Shape of the adonisrc.js file
  */
 export type RcFile = {
@@ -186,6 +202,57 @@ export type RcFile = {
   }
 
   /**
+   * Assembler configuration
+   */
+  assembler?: {
+    /**
+     * Configure a custom runner to start the dev server
+     * and tests. By default we are using ts-node but you
+     * are free to use any other runner
+     */
+    runner?: {
+      name: string
+      command: string
+      args?: string[]
+    }
+
+    /**
+     * When the dev server is started
+     */
+    onDevServerStarted?: AssemblerHookNode<AssemblerHookHandler>[]
+
+    /**
+     * When the dev server is about to start
+     */
+    onDevServerStarting?: AssemblerHookNode<AssemblerHookHandler>[]
+
+    /**
+     * When a source file changes
+     */
+    onSourceFileChanged?: AssemblerHookNode<SourceFileChangedHookHandler>[]
+
+    /**
+     * When the dev server is about to close
+     */
+    onDevServerClosing?: AssemblerHookNode<AssemblerHookHandler>[]
+
+    /**
+     * When the dev server is closed
+     */
+    onDevServerClosed?: AssemblerHookNode<AssemblerHookHandler>[]
+
+    /**
+     * When a build is started
+     */
+    onBuildStarting?: AssemblerHookNode<AssemblerHookHandler>[]
+
+    /**
+     * When a build is completed
+     */
+    onBuildCompleted?: AssemblerHookNode<AssemblerHookHandler>[]
+  }
+
+  /**
    * Register test suites
    */
   tests: {
@@ -226,6 +293,7 @@ export interface RcFileInput {
     timeout?: number
   }
   providers?: (ProviderNode | ProviderNode['file'])[]
+  assembler?: RcFile['assembler']
 }
 
 /**

--- a/tests/rc_file/parser.spec.ts
+++ b/tests/rc_file/parser.spec.ts
@@ -657,7 +657,7 @@ test.group('Rc Parser | assetsBundler', () => {
     )
   })
 
-  test('parse assetsBundler false', ({ assert }) => {
+  test('parse assetsBundler with false value', ({ assert }) => {
     const parser = new RcFileParser({ assetsBundler: false })
 
     assert.deepEqual(parser.parse(), {
@@ -707,6 +707,130 @@ test.group('Rc Parser | directories', () => {
         suites: [],
         timeout: 2000,
         forceExit: true,
+      },
+    })
+  })
+})
+
+test.group('Rc Parser | assembler', () => {
+  test('parse runner properly', ({ assert }) => {
+    const parser = new RcFileParser({
+      assembler: {
+        runner: {
+          name: 'bun',
+          command: 'bun',
+          args: ['--flag'],
+        },
+      },
+    })
+
+    assert.deepEqual(parser.parse(), {
+      raw: {
+        assembler: {
+          runner: {
+            name: 'bun',
+            command: 'bun',
+            args: ['--flag'],
+          },
+        },
+      },
+      typescript: true,
+      preloads: [],
+      directories,
+      metaFiles: [],
+      commands: [],
+      commandsAliases: {},
+      providers: [],
+      tests: {
+        suites: [],
+        timeout: 2000,
+        forceExit: true,
+      },
+      assembler: {
+        runner: {
+          name: 'bun',
+          command: 'bun',
+          args: ['--flag'],
+        },
+      },
+    })
+  })
+
+  test('raise error when runner properties are missing', ({ assert }) => {
+    assert.throws(
+      () =>
+        new RcFileParser({
+          assembler: {
+            runner: {
+              name: 'bun',
+            },
+          },
+        }).parse(),
+      'Invalid assembler.runner entry. Missing command property'
+    )
+
+    assert.throws(
+      () =>
+        new RcFileParser({
+          assembler: {
+            runner: {
+              command: 'bun',
+            },
+          },
+        }).parse(),
+      'Invalid assembler.runner entry. Missing name property'
+    )
+  })
+
+  test('parse assembler hooks properly', ({ assert }) => {
+    const onBuildStarting = () => {}
+    const onBuildCompleted = () => {}
+    const onDevServerClosed = () => {}
+    const onDevServerClosing = () => {}
+    const onDevServerStarted = () => {}
+    const onDevServerStarting = () => {}
+
+    const parser = new RcFileParser({
+      assembler: {
+        onBuildStarting,
+        onBuildCompleted,
+        onDevServerClosed,
+        onDevServerClosing,
+        onDevServerStarted,
+        onDevServerStarting,
+      },
+    })
+
+    assert.deepEqual(parser.parse(), {
+      raw: {
+        assembler: {
+          onBuildStarting,
+          onBuildCompleted,
+          onDevServerClosed,
+          onDevServerClosing,
+          onDevServerStarted,
+          onDevServerStarting,
+        },
+      },
+      typescript: true,
+      preloads: [],
+      directories,
+      metaFiles: [],
+      commands: [],
+      commandsAliases: {},
+      providers: [],
+      tests: {
+        suites: [],
+        timeout: 2000,
+        forceExit: true,
+      },
+      assembler: {
+        onBuildStarting,
+        onBuildCompleted,
+        onDevServerClosed,
+        onDevServerClosing,
+        onDevServerStarted,
+        onDevServerStarting,
       },
     })
   })

--- a/tests/rc_file/parser.spec.ts
+++ b/tests/rc_file/parser.spec.ts
@@ -656,6 +656,27 @@ test.group('Rc Parser | assetsBundler', () => {
       'Invalid assetsBundler entry. Missing name property'
     )
   })
+
+  test('parse assetsBundler false', ({ assert }) => {
+    const parser = new RcFileParser({ assetsBundler: false })
+
+    assert.deepEqual(parser.parse(), {
+      raw: { assetsBundler: false },
+      typescript: true,
+      assetsBundler: false,
+      preloads: [],
+      directories,
+      metaFiles: [],
+      commands: [],
+      commandsAliases: {},
+      providers: [],
+      tests: {
+        suites: [],
+        timeout: 2000,
+        forceExit: true,
+      },
+    })
+  })
 })
 
 test.group('Rc Parser | directories', () => {

--- a/tests/rc_file/parser.spec.ts
+++ b/tests/rc_file/parser.spec.ts
@@ -715,7 +715,7 @@ test.group('Rc Parser | directories', () => {
 test.group('Rc Parser | assembler', () => {
   test('parse runner properly', ({ assert }) => {
     const parser = new RcFileParser({
-      assembler: {
+      unstable_assembler: {
         runner: {
           name: 'bun',
           command: 'bun',
@@ -726,7 +726,7 @@ test.group('Rc Parser | assembler', () => {
 
     assert.deepEqual(parser.parse(), {
       raw: {
-        assembler: {
+        unstable_assembler: {
           runner: {
             name: 'bun',
             command: 'bun',
@@ -746,7 +746,7 @@ test.group('Rc Parser | assembler', () => {
         timeout: 2000,
         forceExit: true,
       },
-      assembler: {
+      unstable_assembler: {
         runner: {
           name: 'bun',
           command: 'bun',
@@ -760,7 +760,7 @@ test.group('Rc Parser | assembler', () => {
     assert.throws(
       () =>
         new RcFileParser({
-          assembler: {
+          unstable_assembler: {
             runner: {
               name: 'bun',
             },
@@ -772,7 +772,7 @@ test.group('Rc Parser | assembler', () => {
     assert.throws(
       () =>
         new RcFileParser({
-          assembler: {
+          unstable_assembler: {
             runner: {
               command: 'bun',
             },
@@ -785,31 +785,22 @@ test.group('Rc Parser | assembler', () => {
   test('parse assembler hooks properly', ({ assert }) => {
     const onBuildStarting = () => {}
     const onBuildCompleted = () => {}
-    const onDevServerClosed = () => {}
-    const onDevServerClosing = () => {}
     const onDevServerStarted = () => {}
-    const onDevServerStarting = () => {}
 
     const parser = new RcFileParser({
-      assembler: {
+      unstable_assembler: {
         onBuildStarting,
         onBuildCompleted,
-        onDevServerClosed,
-        onDevServerClosing,
         onDevServerStarted,
-        onDevServerStarting,
       },
     })
 
     assert.deepEqual(parser.parse(), {
       raw: {
-        assembler: {
+        unstable_assembler: {
           onBuildStarting,
           onBuildCompleted,
-          onDevServerClosed,
-          onDevServerClosing,
           onDevServerStarted,
-          onDevServerStarting,
         },
       },
       typescript: true,
@@ -824,13 +815,10 @@ test.group('Rc Parser | assembler', () => {
         timeout: 2000,
         forceExit: true,
       },
-      assembler: {
+      unstable_assembler: {
         onBuildStarting,
         onBuildCompleted,
-        onDevServerClosed,
-        onDevServerClosing,
         onDevServerStarted,
-        onDevServerStarting,
       },
     })
   })


### PR DESCRIPTION
Added configuration for assembly as explained in this issue https://github.com/adonisjs/insiders/issues/3

Several changes compared to the original RFC: 

- hooks must be defined in different files and default exported, as recommended by Virk
- `assembler.runner` defines the command to be executed to launch the dev server or tests. Just an object in which to define the command and its arguments

---

The code that will manage the import of hook files and their application will live in adonisjs/assembler. I hesitated on this one, but after reflection I think it's the best decision 

- the code will be more or less similar to this https://github.com/japa/runner/blob/develop/src/hooks.ts + we also need to import hooks file.
- This code will super specific to the assembler. It makes more sense to me that it lives in the assembler repo. A modification to it will probably also imply a modification to the assembler. So, from a maintenance point of view, it's easier to keep the two together. No release to do between adonisjs/application and adonisjs/assembler.
- It's not very important because there's not a lot of code, but this code will only be needed for development, so probably better to have it in adonisjs/assembler, which isn't installed in production.