### PR TITLE
feat: presets system

### DIFF
--- a/src/rc_file/parser.ts
+++ b/src/rc_file/parser.ts
@@ -13,7 +13,14 @@ import { ObjectBuilder } from '@poppinss/utils'
 
 import * as errors from '../errors.js'
 import { directories } from '../directories.js'
-import type { AppEnvironments, MetaFileNode, PreloadNode, ProviderNode, RcFile } from '../types.js'
+import type {
+  AppEnvironments,
+  MetaFileNode,
+  PreloadNode,
+  PresetFn,
+  ProviderNode,
+  RcFile,
+} from '../types.js'
 
 /**
  * Rc file parser is used to parse and validate the `adonisrc.js` file contents.
@@ -236,13 +243,22 @@ export class RcFileParser {
   }
 
   /**
+   * Apply presets functions to the given rcFile
+   */
+  #applyPresets(rcFile: RcFile) {
+    const presets: PresetFn[] = this.#rcFile.raw.presets || []
+
+    presets.forEach((preset) => preset({ rcFile }))
+  }
+
+  /**
    * Parse and validate file contents and merge them with defaults
    */
   parse(): RcFile {
     const assembler = this.#getAssembler()
     const assetsBundler = this.#getAssetsBundler()
 
-    return {
+    const rcFile = {
       typescript: this.#rcFile.typescript,
       ...(assembler ? { assembler } : {}),
       ...(assetsBundler !== undefined ? { assetsBundler } : {}),
@@ -259,5 +275,8 @@ export class RcFileParser {
       },
       raw: this.#rcFile.raw,
     }
+
+    this.#applyPresets(rcFile)
+    return rcFile
   }
 }

--- a/src/rc_file/parser.ts
+++ b/src/rc_file/parser.ts
@@ -246,7 +246,7 @@ export class RcFileParser {
    * Apply presets functions to the given rcFile
    */
   #applyPresets(rcFile: RcFile) {
-    const presets: PresetFn[] = this.#rcFile.raw.presets || []
+    const presets: PresetFn[] = this.#rcFile.raw?.presets || []
 
     presets.forEach((preset) => preset({ rcFile }))
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,11 @@ export type HooksState<ContainerBindings extends Record<any, any>> = [
 ]
 
 /**
+ * Shape of the rc file preset function
+ */
+export type PresetFn = (options: { rcFile: RcFile }) => void | Promise<void>
+
+/**
  * Shape of directories object with known and unknown
  * directories
  */
@@ -276,6 +281,7 @@ export type RcFile = {
  * RcFile input is the partial copy of the RcFile
  */
 export interface RcFileInput {
+  presets?: PresetFn[]
   assetsBundler?: RcFile['assetsBundler']
   typescript?: RcFile['typescript']
   directories?: Partial<DirectoriesNode> & { [key: string]: string }


### PR DESCRIPTION
Added presets as explained in this issue https://github.com/adonisjs/insiders/issues/3

The preset system is quite simple. Note also that there is no validation system. we don't check that the RC file is valid after applying the presets. Like theses validations for example

```ts
if (!normalizedProvider.file) {
  throw new errors.E_MISSING_PROVIDER_FILE([inspect(provider)])
}

if (typeof normalizedProvider.file !== 'function') {
  throw new errors.E_INVALID_PROVIDER([inspect(provider)])
}
```
      
```ts
if (!this.#rcFile.assembler.runner.name) {
	throw new errors.E_MISSING_ASSEMBLER_RUNNER_NAME()
}

if (!this.#rcFile.assembler.runner.command) {
  throw new errors.E_MISSING_ASSEMBLER_RUNNER_COMMAND()
}
```

But i believe this is okay like that. Preset authors are supposed to be careful about what they do