### PR TITLE
feat: add tracing channels support for preload files

### DIFF
--- a/src/managers/preloads.ts
+++ b/src/managers/preloads.ts
@@ -9,6 +9,7 @@
 
 import debug from '../debug.ts'
 import type { AppEnvironments, PreloadNode } from '../types.ts'
+import { preloadImport } from '../tracing_channels.ts'
 
 /**
  * The PreloadsManager class is used to resolve and import preload modules.
@@ -110,7 +111,15 @@ export class PreloadsManager {
     const preloads = this.#list.filter((preload) => this.#filterByEnvironment(preload))
     debug('preloading modules %O', preloads)
 
-    await Promise.all(preloads.map((preload) => preload.file()))
+    await Promise.all(
+      preloads.map((preload) =>
+        preloadImport.tracePromise(
+          preload.file as () => Promise<void>,
+          preloadImport.hasSubscribers ? { file: preload.file } : undefined,
+          preload
+        )
+      )
+    )
 
     this.#list = []
   }

--- a/src/tracing_channels.ts
+++ b/src/tracing_channels.ts
@@ -8,7 +8,7 @@
  */
 
 import diagnostics_channel from 'node:diagnostics_channel'
-import { type ContainerProviderContract } from './types.ts'
+import { type ContainerProviderContract, type PreloadNode } from './types.ts'
 
 /**
  * Tracing channel for service provider register lifecycle hook.
@@ -115,3 +115,24 @@ export const providerShutdown = diagnostics_channel.tracingChannel<
   'adonisjs.provider.shutdown',
   { provider: ContainerProviderContract }
 >('adonisjs.provider.shutdown')
+
+/**
+ * Tracing channel for preload file import.
+ * This channel traces when a preload module is imported during
+ * the application start phase.
+ *
+ * @example
+ * // Monitor preload imports
+ * preloadImport.subscribe({
+ *   asyncStart(data) {
+ *     console.log('Importing preload:', data.file.toString())
+ *   },
+ *   asyncEnd(data) {
+ *     console.log('Preload imported:', data.file.toString())
+ *   }
+ * })
+ */
+export const preloadImport = diagnostics_channel.tracingChannel<
+  'adonisjs.preload.import',
+  { file: PreloadNode['file'] }
+>('adonisjs.preload.import')

--- a/tests/application/preloads.spec.ts
+++ b/tests/application/preloads.spec.ts
@@ -12,6 +12,7 @@ import { test } from '@japa/runner'
 import { fileURLToPath } from 'node:url'
 import { outputFile, remove } from 'fs-extra'
 import { Application } from '../../src/application.ts'
+import { preloadImport } from '../../src/tracing_channels.ts'
 
 const BASE_URL = new URL('./app/', import.meta.url)
 const BASE_PATH = fileURLToPath(BASE_URL)
@@ -221,6 +222,52 @@ test.group('Application | preloads', (group) => {
     await app.boot()
     await app.start(() => {})
 
+    assert.equal(process.env.HAS_ROUTES, 'true')
+  })
+
+  test('trace preload imports', async ({ assert, cleanup }) => {
+    cleanup(() => {
+      delete process.env.HAS_ROUTES
+    })
+
+    await outputFile(
+      join(BASE_PATH, './routes.ts'),
+      `
+      process.env.HAS_ROUTES = 'true'
+      `
+    )
+
+    const app = new Application(BASE_URL, {
+      environment: 'web',
+    })
+
+    app.rcContents({
+      preloads: [
+        {
+          file: () => import(new URL('./routes.js?v=30', BASE_URL).href),
+          environment: ['web'],
+          optional: false,
+        },
+      ],
+    })
+
+    const spans: any[] = []
+    preloadImport.subscribe({
+      asyncStart(message: any) {
+        spans.push({ file: message.file, startTime: process.hrtime() })
+      },
+      asyncEnd() {
+        const span = spans[spans.length - 1]
+        span.duration = process.hrtime(span.startTime)
+      },
+    } as any)
+
+    await app.init()
+    await app.boot()
+    await app.start(() => {})
+
+    assert.lengthOf(spans, 1)
+    assert.properties(spans[0], ['file', 'startTime', 'duration'])
     assert.equal(process.env.HAS_ROUTES, 'true')
   })
 })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds tracing channel support for preload files, mirroring the existing pattern used for service providers. A new `adonisjs.preload.import` diagnostics channel is created and integrated into the `PreloadsManager`, allowing external tools and monitoring systems to trace preload module imports during the application start phase. Each preload import is wrapped with `tracePromise`, using the same `hasSubscribers` optimization to avoid unnecessary allocations when no subscribers are active.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
